### PR TITLE
Fix the capture order to go from the fastest to the slowest exposure

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -1130,11 +1130,12 @@ didFinishProcessingPhoto:(AVCapturePhoto *)photo
           NSUInteger startIndex = itemsRemaining - length;
           NSRange range = NSMakeRange(startIndex, length);
           NSArray *subarray = [self.exposures subarrayWithRange:range];
-          [exposuresBrackets addObject:subarray];
+          NSArray* reversedSubArray = [[subarray reverseObjectEnumerator] allObjects];
+          [exposuresBrackets addObject:reversedSubArray];
           itemsRemaining-=range.length;
       }
 
-      self.exposureBrackets = exposuresBrackets;
+      self.exposureBrackets = [[[exposuresBrackets reverseObjectEnumerator] allObjects] mutableCopy];
       [self captureBracket];
 #endif
   });


### PR DESCRIPTION
This was causing an artifact when taking a picture with the latest iphone 12 family